### PR TITLE
Refactor to use average proc memory and max proc memory

### DIFF
--- a/conf/apache/conf.go
+++ b/conf/apache/conf.go
@@ -17,28 +17,34 @@ const tpl = `<IfModule mpm_prefork_module>
 
 // Apache struct
 type Apache struct {
-	max  int
-	proc int
+	totalMemory int
+	avgProc     int
+	maxProc     int
 }
 
 func init() {
 	conf.Register("apache", &Apache{})
 }
 
-// Max is the max available memory.
-func (a *Apache) Max(m int) {
-	a.max = m
+// TotalMemory is the max available totalMemory.
+func (a *Apache) TotalMemory(m int) {
+	a.totalMemory = m
 }
 
-// Proc is the max proc size.
-func (a *Apache) Proc(pr int) {
-	a.proc = pr
+// AvgProc is the average proc size.
+func (a *Apache) AvgProc(pr int) {
+	a.avgProc = pr
+}
+
+// MaxProc is the average proc size.
+func (a *Apache) MaxProc(pr int) {
+	a.maxProc = pr
 }
 
 // Build builds the template.
 func (a *Apache) Build() (string, error) {
 	// This is the number of concurrent processes that can be at a given time.
-	maxClients := a.max / a.proc
+	maxClients := a.totalMemory / a.avgProc
 
 	// We setup the templating with a special "divide" function, that way we can do inline division.
 	fm := template.FuncMap{"divide": func(a, b int) int {
@@ -46,7 +52,7 @@ func (a *Apache) Build() (string, error) {
 	}}
 	t := template.Must(template.New(tpl).Funcs(fm).Parse(tpl))
 
-	// Write the contents to memory.
+	// Write the contents to totalMemory.
 	buf := new(bytes.Buffer)
 	err := t.Execute(buf, maxClients)
 	if err != nil {

--- a/conf/apache/conf_test.go
+++ b/conf/apache/conf_test.go
@@ -16,8 +16,9 @@ const r = `<IfModule mpm_prefork_module>
 
 func TestApacheBuild(t *testing.T) {
 	a := Apache{}
-	a.Max(2048)
-	a.Proc(64)
+	a.TotalMemory(2048)
+	a.AvgProc(64)
+	a.MaxProc(64)
 	b, _ := a.Build()
 	assert.Equal(t, r, b, "Generated correct Apache configuration.")
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -6,8 +6,9 @@ import (
 
 // Conf interface
 type Conf interface {
-	Max(int)
-	Proc(int)
+	TotalMemory(int)
+	AvgProc(int)
+	MaxProc(int)
 	Build() (string, error)
 }
 
@@ -29,10 +30,11 @@ func Register(name string, balancer Conf) error {
 }
 
 // Generate initializes a new configuration, sets the config and generates a file.
-func Generate(name string, max, proc int) (string, error) {
+func Generate(name string, memory, avgProc int, maxProc int) (string, error) {
 	if t, exists := Confs[name]; exists {
-		t.Max(max)
-		t.Proc(proc)
+		t.TotalMemory(memory)
+		t.AvgProc(avgProc)
+		t.MaxProc(maxProc)
 		c, err := t.Build()
 		if err != nil {
 			return "", err
@@ -41,5 +43,5 @@ func Generate(name string, max, proc int) (string, error) {
 		return c, nil
 	}
 
-	return "", errors.New("could not find the tpl")
+	return "", errors.New("could not find the template")
 }

--- a/conf/passenger/conf.go
+++ b/conf/passenger/conf.go
@@ -13,33 +13,39 @@ const tpl = `<IfModule mod_passenger.c>
 
 // Passenger struct
 type Passenger struct {
-	max  int
-	proc int
+	totalMemory int
+	avgProc     int
+	maxProc     int
 }
 
 func init() {
 	conf.Register("passenger", &Passenger{})
 }
 
-// Max is the maximum memory.
-func (a *Passenger) Max(m int) {
-	a.max = m
+// TotalMemory is the total available totalMemory.
+func (a *Passenger) TotalMemory(m int) {
+	a.totalMemory = m
 }
 
-// Proc is the max proc size.
-func (a *Passenger) Proc(pr int) {
-	a.proc = pr
+// AvgProc is the totalMemory avgProc size.
+func (a *Passenger) AvgProc(pr int) {
+	a.avgProc = pr
+}
+
+// MaxProc is the totalMemory avgProc size.
+func (a *Passenger) MaxProc(pr int) {
+	a.maxProc = pr
 }
 
 // Build builds the template.
 func (a *Passenger) Build() (string, error) {
 	// This is the number of concurrent processes that can be at a given time.
-	maxClients := a.max / a.proc
+	maxClients := a.totalMemory / a.avgProc
 
 	// We setup the templating with a special "divide" function, that way we can do inline division.
 	t := template.Must(template.New(tpl).Parse(tpl))
 
-	// Write the contents to memory.
+	// Write the contents to totalMemory.
 	buf := new(bytes.Buffer)
 	err := t.Execute(buf, maxClients)
 	if err != nil {

--- a/conf/passenger/conf_test.go
+++ b/conf/passenger/conf_test.go
@@ -12,8 +12,9 @@ const r = `<IfModule mod_passenger.c>
 
 func TestPassengerBuild(t *testing.T) {
 	p := Passenger{}
-	p.Max(2048)
-	p.Proc(64)
+	p.TotalMemory(2048)
+	p.AvgProc(64)
+	p.MaxProc(128)
 	b, _ := p.Build()
 	assert.Equal(t, r, b, "Generated correct Passenger configuration.")
 }

--- a/conf/php/conf.go
+++ b/conf/php/conf.go
@@ -11,31 +11,37 @@ const tpl = `memory_limit = {{ . }}M`
 
 // PHP struct.
 type PHP struct {
-	max  int
-	proc int
+	totalMemory int
+	avgProc     int
+	maxProc     int
 }
 
 func init() {
 	conf.Register("php", &PHP{})
 }
 
-// Max is the max available memory.
-func (p *PHP) Max(m int) {
-	p.max = m
+// TotalMemory is the total available totalMemory.
+func (p *PHP) TotalMemory(m int) {
+	p.totalMemory = m
 }
 
-// Proc is the max proc size.
-func (p *PHP) Proc(pr int) {
-	p.proc = pr
+// AvgProc is the max proc size.
+func (p *PHP) AvgProc(pr int) {
+	p.avgProc = pr
+}
+
+// MaxProc is the max proc size.
+func (p *PHP) MaxProc(pr int) {
+	p.maxProc = pr
 }
 
 // Build builds the template.
 func (p *PHP) Build() (string, error) {
 	t := template.Must(template.New(tpl).Parse(tpl))
 
-	// Write the contents to memory.
+	// Write the contents to memory_limit.
 	buf := new(bytes.Buffer)
-	err := t.Execute(buf, p.proc)
+	err := t.Execute(buf, p.maxProc)
 	if err != nil {
 		return "", err
 	}

--- a/conf/php/conf_test.go
+++ b/conf/php/conf_test.go
@@ -10,8 +10,9 @@ const r = `memory_limit = 64M`
 
 func TestPHPBuild(t *testing.T) {
 	a := PHP{}
-	a.Max(2048)
-	a.Proc(64)
+	a.TotalMemory(2048)
+	a.AvgProc(64)
+	a.MaxProc(64)
 	b, _ := a.Build()
 	assert.Equal(t, r, b, "Generated correct PHP configuration.")
 }

--- a/main.go
+++ b/main.go
@@ -13,20 +13,18 @@ import (
 )
 
 var (
-	cliConf       = kingpin.Flag("conf", "The type of configuration file to return").Default("apache").OverrideDefaultFromEnvar("TUNER_CONF").String()
-	cliMax        = kingpin.Flag("max", "Max memory allocated to this instance").Default("512").OverrideDefaultFromEnvar("TUNER_MAX").Int()
-	cliProc       = kingpin.Flag("proc", "The size of the PHP proccess.").Default("128").OverrideDefaultFromEnvar("TUNER_PROC").Int()
-	cliMultiplier = kingpin.Flag("multiplier", "The multiplier for calculating apache max clients").Default("2").OverrideDefaultFromEnvar("TUNER_MULTIPLIER").Int()
+	cliConf    = kingpin.Flag("conf", "The type of configuration file to return").Default("apache").Envar("TUNER_CONF").String()
+	cliMemory  = kingpin.Flag("memory", "Total available memory.").Default("512").Envar("TUNER_MEMORY").Int()
+	cliAvgProc = kingpin.Flag("avg-proc", "The average memory size of a process.").Default("64").Envar("TUNER_AVG_PROC").Int()
+	cliMaxProc = kingpin.Flag("max-proc", "The maximum allowed memory size of a process.").Default("128").Envar("TUNER_MAX_PROC").Int()
 )
 
 func main() {
 	kingpin.Parse()
 
-	// Apply the mupltier here, the configurations should not have a account for this.
-	multiMax := *cliMax * *cliMultiplier
 
 	// Get the configuration object.
-	c, err := conf.Generate(*cliConf, multiMax, *cliProc)
+	c, err := conf.Generate(*cliConf, *cliMemory, *cliAvgProc, *cliMaxProc)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
#### What does this PR do?

- Removes the multiplier arg
- Adds an average proc arg
- Renames some fields to make it easier to grok

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots (if appropriate)


#### Questions:


##### Does any external documentation require updating?


##### Does this changeset require specific versions of supporting software?
(i.e. Go / Terraform / Docker)